### PR TITLE
Fix setting value without options

### DIFF
--- a/src/select.jsx
+++ b/src/select.jsx
@@ -10,10 +10,6 @@ class FormSelect extends React.Component {
 
         const { value, options } = props;
 
-        this.state = {
-            index: Util.findIndex(value, options),
-        };
-
         this.internalSelect = this.internalSelect.bind(this);
     }
 
@@ -39,18 +35,14 @@ class FormSelect extends React.Component {
 
         Util.internalSelect(
             this.props,
-            value,
-            () => (
-                this.setState({
-                    index: Util.findIndex(value, options)
-                })
-            )
+            value
         );
     }
 
     render() {
         const { options, placeholder, selectProps } = this.props;
-        const { index } = this.state;
+
+        const index = Util.findIndex(value, options);
 
         return (
             <Select


### PR DESCRIPTION
The current code didn't allow the value to be changed if the options were not changed. I've moved calculating the index to the render method as that will only be called on initial render or prop change anyway.